### PR TITLE
Split node subscription out to expose more logging detail

### DIFF
--- a/common/drivers/plcConnectorOPCUA.go
+++ b/common/drivers/plcConnectorOPCUA.go
@@ -181,9 +181,20 @@ func (s *plcConnectorOPCUA) GetTagHistory(startTS time.Time, endTS time.Time, in
 //
 func (s *plcConnectorOPCUA) startChanSub(clientName string, ctx context.Context, m *monitor.NodeMonitor, interval, lag time.Duration, nodes ...string) {
 	ch := make(chan *monitor.DataChangeMessage, 16)
-	sub, err := m.ChanSubscribe(ctx, &opcua.SubscriptionParameters{Interval: interval}, ch, nodes...)
+	log.Printf("Opening a channel subscription")
+	//Open a new channel, don't add the nodes just yet
+	sub, err := m.ChanSubscribe(ctx, &opcua.SubscriptionParameters{Interval: interval}, ch)
 	if err != nil {
 		log.Fatal(err)
+	}
+	log.Printf("Adding nodes to channel subscription:")
+	//Add the nodes one by one so their names appear in the log
+	for i := range nodes {
+		log.Printf("Adding node: %s", nodes[i])
+		err := sub.AddNodes(nodes[i])
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	log.Printf("%s subscribed with id=%d  (%+v)", clientName, sub.SubscriptionID(), nodes)
 


### PR DESCRIPTION
The service performs a fatal close if the NodeId in Libre is not an exact match with the NodeId in the OPC Server

This change split the subscription process into one call per node to permit more logging detail and to make the situation more obvious to the engineeer

**### Old logging under fault:**

`2021/08/12 14:11:48 The node id refers to a node that does not exist in the server address space. StatusBadNodeIDUnknown (0x80340000)
Exiting.`

New logging when working

![image](https://user-images.githubusercontent.com/82369648/129242231-3ae3b830-b6ce-42e3-88e2-de959721a3c3.png)


New Logging under fault

![image](https://user-images.githubusercontent.com/82369648/129242396-60312c7a-b22d-4213-acdb-a4fbdd69f4f9.png)




