### PR TITLE
Added delay time to eventDefinitionEvaluator

### DIFF
--- a/common/core/domain/serverdomain.go
+++ b/common/core/domain/serverdomain.go
@@ -32,6 +32,7 @@ type StdMessageStruct struct {
 	TagQuality    int
 	Err           error
 	ChangedTime   time.Time
+	OldChangedTime   time.Time
 	Category      string
 	Topic		  string
 	ReplyTopic    string


### PR DESCRIPTION
We sometimes need to wait a little bit before preparing the payload to ensure all the fields have been updated. Added a configuration parameter to wait after the trigger has evaluated and before the payload variables are retrieved