### PR TITLE
Add calendarService cache hydration

### DIFF
--- a/common/core/domain/calendar.go
+++ b/common/core/domain/calendar.go
@@ -291,7 +291,7 @@ type timeFilter struct {
 	allYearDays  bool
 }
 
-func (timeFilter *timeFilter) compare(time time.Time) bool {
+func (timeFilter *timeFilter) compareTime(time time.Time) bool {
 	if !timeFilter.allSecond && !intExists(timeFilter.def.BySecond, time.Second()) {
 		return false
 	}
@@ -301,6 +301,15 @@ func (timeFilter *timeFilter) compare(time time.Time) bool {
 	}
 
 	if !timeFilter.allHours && !intExists(timeFilter.def.ByHour, time.Hour()) {
+		return false
+	}
+
+	return true
+}
+
+func (timeFilter *timeFilter) compare(time time.Time) bool {
+
+	if !timeFilter.compareTime(time) {
 		return false
 	}
 

--- a/common/core/domain/entities.go
+++ b/common/core/domain/entities.go
@@ -91,3 +91,21 @@ type DataSubscription struct {
 	Status         string                `json:"status,omitempty"`
 	Channel        chan *json.RawMessage `json:"-"`
 }
+
+func DeduplicateEquipment(equipments []Equipment) (result []Equipment) {
+	for _, equipment := range equipments {
+		if !ContainsEquipment(result, equipment) {
+			result = append(result, equipment)
+		}
+	}
+	return result
+}
+
+func ContainsEquipment(equipments []Equipment, equipment Equipment) bool {
+	for i := range equipments {
+		if equipments[i].Id == equipment.Id {
+			return true
+		}
+	}
+	return false
+}

--- a/common/core/domain/entities_test.go
+++ b/common/core/domain/entities_test.go
@@ -1,0 +1,88 @@
+package domain
+
+import "testing"
+
+func Test_ContainsEquipment(t *testing.T) {
+
+	var equipments = []Equipment{
+		{
+			Id: "1",
+		},
+		{
+			Id: "2",
+		},
+		{
+			Id: "",
+		},
+		{
+			Id: "3",
+		},
+		{
+			Id: "3",
+		},
+	}
+
+	if !ContainsEquipment(equipments, Equipment{Id: "1"}) {
+		t.Errorf("Expect equipment to contain equipment with Id: 1")
+	}
+
+	if !ContainsEquipment(equipments, Equipment{Id: "2"}) {
+		t.Errorf("Expect equipment to contain equipment with Id: 2")
+	}
+
+	if !ContainsEquipment(equipments, Equipment{Id: "3"}) {
+		t.Errorf("Expect equipment to contain equipment with Id: 3")
+	}
+
+	if !ContainsEquipment(equipments, Equipment{}) {
+		t.Errorf("Expect equipment to contain equipment with out an Id")
+	}
+
+	if ContainsEquipment(equipments, Equipment{Id: "0"}) {
+		t.Errorf("Expect equipment to NOT to contain equipment with id: 0")
+	}
+
+}
+
+func Test_DeduplicateEquipment(t *testing.T) {
+	var equipments = []Equipment{
+		{
+			Id: "1",
+		},
+		{
+			Id: "2",
+		},
+		{
+			Id: "",
+		},
+		{
+			Id: "3",
+		},
+		{
+			Id: "3",
+		},
+	}
+
+	dedupEquipments := DeduplicateEquipment(equipments)
+
+	if !ContainsEquipment(dedupEquipments, Equipment{Id: "1"}) {
+		t.Errorf("Expect equipment to contain equipment with Id: 1")
+	}
+
+	if !ContainsEquipment(dedupEquipments, Equipment{Id: "2"}) {
+		t.Errorf("Expect equipment to contain equipment with Id: 2")
+	}
+
+	if !ContainsEquipment(dedupEquipments, Equipment{Id: "3"}) {
+		t.Errorf("Expect equipment to contain equipment with Id: 3")
+	}
+
+	if !ContainsEquipment(dedupEquipments, Equipment{}) {
+		t.Errorf("Expect equipment to contain equipment with out an Id")
+	}
+
+	if len(dedupEquipments) != 4 {
+		t.Errorf("Expect deduplicated equipments to contain 4 elements")
+	}
+
+}

--- a/common/core/domain/serverdomain.go
+++ b/common/core/domain/serverdomain.go
@@ -62,6 +62,8 @@ type StdMessageStruct struct {
 	History           *dataframe.DataFrame `json:"History,omitempty"`
 }
 
+const DataTypeString = "STRING"
+
 func ConvertTypes(messageStruct StdMessageStruct) StdMessageStruct {
 	switch messageStruct.ItemDataType {
 	case "FLOAT":
@@ -121,7 +123,7 @@ func ConvertPropertyValueStringToTypedValue(propType string, rawVal interface{})
 	case string:
 		var strVal string = fmt.Sprintf("%s", rawVal)
 		switch propType {
-		case "STRING":
+		case DataTypeString:
 			val = rawVal
 		case "BOOL":
 			if strVal == "" {

--- a/common/core/services/calendarService_test.go
+++ b/common/core/services/calendarService_test.go
@@ -381,7 +381,22 @@ func TestCalendarService(t *testing.T) {
 	// Check Cache Values
 	cachedMessages = []domain.StdMessageStruct{expectedCategoryMessage, expectedEntryMessage}
 	cacheMessageEquipment = testEquipmentName
-	service.Start()
+	err = service.Start()
+	if err != nil {
+		t.Errorf("TestCalendarService failed, expected no error; got %s", err)
+	}
+	time.Sleep(2 * time.Second)
+
+breaker:
+	for {
+		select {
+		case actualMessage := <-stdMessageChan:
+			t.Errorf("Expected no messages to be produced; but got %v\n", actualMessage)
+			break breaker
+		case <-time.After(3 * time.Second):
+			break breaker
+		}
+	}
 
 	t.Logf("Complete CalendarService")
 }

--- a/common/core/services/calendarService_test.go
+++ b/common/core/services/calendarService_test.go
@@ -13,8 +13,12 @@ import (
 
 var stdMessageChan chan domain.StdMessageStruct
 
+var cachedMessages []domain.StdMessageStruct
+var cacheMessageEquipment string
+
 type FakeLibreConnector struct {
-	nextError bool
+	nextError    bool
+	CachedValues map[string][]domain.StdMessageStruct
 }
 
 func (libreConnector FakeLibreConnector) Connect(clientID string) error {
@@ -30,7 +34,18 @@ func (libreConnector FakeLibreConnector) WriteTags(outTagDefs []domain.StdMessag
 }
 
 func (libreConnector FakeLibreConnector) ListenForEdgeTagChanges(c chan domain.StdMessageStruct, changeFilter map[string]interface{}) {
-	panic("implement me")
+	for key, val := range changeFilter {
+		if key == "EQ" {
+			switch v := val.(type) {
+			case string:
+				if v == cacheMessageEquipment {
+					for _, message := range cachedMessages {
+						c <- message
+					}
+				}
+			}
+		}
+	}
 }
 
 func (libreConnector FakeLibreConnector) GetTagHistory(startTS time.Time, endTS time.Time, inTagDefs []domain.StdMessageStruct) []domain.StdMessageStruct {
@@ -102,6 +117,8 @@ func (fakeLibreDataStore FakeLibreDataStore) GetAllActiveWorkCalendar() ([]domai
 func TestCalendarService(t *testing.T) {
 	stdMessageChan = make(chan domain.StdMessageStruct)
 
+	testEquipmentName := "Site/Area/Line"
+
 	now := time.Now().UTC()
 	fakeLibreConnector := FakeLibreConnector{}
 	fakeLibreDataStore := FakeLibreDataStore{
@@ -129,7 +146,7 @@ func TestCalendarService(t *testing.T) {
 				Equipment: []domain.Equipment{
 					{
 						Id:          "",
-						Name:        "Site/Area/Line",
+						Name:        testEquipmentName,
 						Description: "",
 					},
 				},
@@ -288,11 +305,11 @@ func TestCalendarService(t *testing.T) {
 		ItemNameExt:      map[string]string{},
 		ItemId:           "",
 		ItemValue:        string(domain.PlannedBusyTime),
-		ItemDataType:     "STRING",
+		ItemDataType:     domain.DataTypeString,
 		TagQuality:       1,
 		Err:              nil,
 		ChangedTimestamp: time.Now().UTC(),
-		Category:         "TAGDATA",
+		Category:         domain.SVCRQST_TAGDATA,
 		Topic:            fakeLibreDataStore.WorkCalendars[0].Equipment[0].Name + "/workCalendarCategory",
 	}
 
@@ -303,11 +320,11 @@ func TestCalendarService(t *testing.T) {
 		ItemNameExt:      map[string]string{},
 		ItemId:           "",
 		ItemValue:        "Shift A",
-		ItemDataType:     "STRING",
+		ItemDataType:     domain.DataTypeString,
 		TagQuality:       1,
 		Err:              nil,
 		ChangedTimestamp: time.Now().UTC(),
-		Category:         "TAGDATA",
+		Category:         domain.SVCRQST_TAGDATA,
 		Topic:            fakeLibreDataStore.WorkCalendars[0].Equipment[0].Name + "/workCalendarEntry",
 	}
 
@@ -360,6 +377,11 @@ func TestCalendarService(t *testing.T) {
 	if GetCalendarServiceInstance() != service {
 		t.Errorf("TestCalendarService get/set serivceInstance failed")
 	}
+
+	// Check Cache Values
+	cachedMessages = []domain.StdMessageStruct{expectedCategoryMessage, expectedEntryMessage}
+	cacheMessageEquipment = testEquipmentName
+	service.Start()
 
 	t.Logf("Complete CalendarService")
 }


### PR DESCRIPTION
When the calendarService is restarted it triggers another workCalendarEntry & workCalendarType equipment tag change. To prevent this we read the values in broker and hydrate our cache so only messages for changed or new equipment will be sent.

### Add
- Add cache hydration to calendarService
- Add const for STRING StdMessageStruct DataType
- Add DeduplicateEquipment Array and ContainsEquipment
- Add test for calendarService cache hydration

### Change
- Change calendarService stopped message to go routine completion

### Fix
- Fix cognitive complexity of timeFilter comparison in domain
- Fix calendarService re-publishing on startup